### PR TITLE
修复一些错误

### DIFF
--- a/onepiece/image_cache.py
+++ b/onepiece/image_cache.py
@@ -133,7 +133,7 @@ class ImageCache():
         future_list = []
         for idx, image_url in enumerate(image_urls, start=1):
             ext = cls.find_suffix(image_url)
-            target_path = os.path.join(output_dir, "{}.{}".format(idx, ext))
+            target_path = os.path.join(output_dir.rstrip(), "{}.{}".format(idx, ext))
             future = pool.submit(cls.download_image, image_url=image_url, target_path=target_path)
             future_list.append(future)
 

--- a/onepiece/utils/__init__.py
+++ b/onepiece/utils/__init__.py
@@ -20,7 +20,7 @@ def parser_chapter_str(chapter_str, last_chapter_number, is_all=None):
     :return list number_list: [1, 2, 3, 4, ...]
     """
     if is_all:
-        return list(range(1, last_chapter_number))
+        return list(range(1, last_chapter_number + 1))
 
     try:
         chapter_number = int(chapter_str)


### PR DESCRIPTION
1、因range界标设置错误导致的-all选项下载不完全
2、因b站某些漫画没有标题导致文件夹路径后面出现多余空格被操作系统去除，导致下载时找不到路径（b漫：mc25733）